### PR TITLE
Fix random number utility

### DIFF
--- a/src/services/notificationService.tsx
+++ b/src/services/notificationService.tsx
@@ -75,7 +75,7 @@ export const ToastifyNotification: React.FC<ToastifyNotificationProps> = ({ titl
  * Generates a random three-digit number.
  */
 function generateRandom3DigitNumber(): number {
-    return Math.floor(Math.random() * 999999) + 100000;
+    return Math.floor(Math.random() * 900) + 100;
 }
 
 /**


### PR DESCRIPTION
## Summary
- generate a three-digit number when creating notifications

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846acd2ce2c8329bbb0540f799cbb66