### PR TITLE
Fix notification random digit bug

### DIFF
--- a/src/services/notificationService.test.ts
+++ b/src/services/notificationService.test.ts
@@ -1,0 +1,11 @@
+import { generateRandom3DigitNumber } from './notificationService';
+
+describe('generateRandom3DigitNumber', () => {
+    it('returns a three-digit number between 100 and 999', () => {
+        for (let i = 0; i < 100; i++) {
+            const num = generateRandom3DigitNumber();
+            expect(num).toBeGreaterThanOrEqual(100);
+            expect(num).toBeLessThanOrEqual(999);
+        }
+    });
+});

--- a/src/services/notificationService.tsx
+++ b/src/services/notificationService.tsx
@@ -74,8 +74,8 @@ export const ToastifyNotification: React.FC<ToastifyNotificationProps> = ({ titl
 /**
  * Generates a random three-digit number.
  */
-function generateRandom3DigitNumber(): number {
-    return Math.floor(Math.random() * 999999) + 100000;
+export function generateRandom3DigitNumber(): number {
+    return Math.floor(Math.random() * 900) + 100;
 }
 
 /**


### PR DESCRIPTION
## Summary
- export generateRandom3DigitNumber and fix its output range
- add a unit test for generateRandom3DigitNumber

## Testing
- `npm test -- -w=0` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68401b140a8c8329a236cdace0e5d50d